### PR TITLE
Add Codex Quantum Tutor API

### DIFF
--- a/codex_quantum_tutor/README.md
+++ b/codex_quantum_tutor/README.md
@@ -1,0 +1,33 @@
+# Codex Quantum Tutor
+
+API sencilla basada en FastAPI que usa OpenAI Codex o GPT-4 para generar código a partir de prompts.
+
+## Instalación
+
+```bash
+pip install -r requirements.txt
+```
+
+Crear un archivo `.env` con tu clave de OpenAI:
+
+```
+OPENAI_API_KEY=tu_clave
+```
+
+## Uso
+
+Iniciar la aplicación con:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Enviar un POST a `/generate` con un JSON que contenga el campo `prompt`.
+
+Ejemplo usando `curl`:
+
+```bash
+curl -X POST http://localhost:8000/generate \
+  -H "Content-Type: application/json" \
+  -d @test_prompt.json
+```

--- a/codex_quantum_tutor/app/main.py
+++ b/codex_quantum_tutor/app/main.py
@@ -1,0 +1,42 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import openai
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+api_key = os.getenv("OPENAI_API_KEY")
+if not api_key:
+    raise RuntimeError("OPENAI_API_KEY not set")
+
+openai.api_key = api_key
+
+app = FastAPI(title="Codex Quantum Tutor")
+
+class Prompt(BaseModel):
+    prompt: str
+
+@app.post("/generate")
+async def generate_code(data: Prompt):
+    try:
+        # Try GPT-4 via chat completion
+        try:
+            chat_resp = openai.ChatCompletion.create(
+                model="gpt-4",
+                messages=[{"role": "user", "content": data.prompt}],
+                max_tokens=400,
+                temperature=0.3,
+            )
+            text = chat_resp.choices[0].message.content
+        except Exception:
+            resp = openai.Completion.create(
+                model="code-davinci-002",
+                prompt=data.prompt,
+                max_tokens=400,
+                temperature=0.3,
+            )
+            text = resp.choices[0].text
+        return {"code": text.strip()}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/codex_quantum_tutor/requirements.txt
+++ b/codex_quantum_tutor/requirements.txt
@@ -1,0 +1,4 @@
+openai
+fastapi
+uvicorn
+python-dotenv

--- a/codex_quantum_tutor/test_prompt.json
+++ b/codex_quantum_tutor/test_prompt.json
@@ -1,0 +1,3 @@
+{
+  "prompt": "Escribe un circuito en Qiskit que cree un estado de Bell y mide los qubits"
+}


### PR DESCRIPTION
## Summary
- add minimal FastAPI backend using OpenAI API
- load OpenAI key from `.env`
- provide requirements and basic README
- include example test prompt for curl/Postman

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6848010e5a848326997a195d5369795f