### PR TITLE
Add explanation step to /generate endpoint

### DIFF
--- a/codex_quantum_tutor/README.md
+++ b/codex_quantum_tutor/README.md
@@ -1,0 +1,39 @@
+# Codex Quantum Tutor
+
+API sencilla basada en FastAPI que usa OpenAI Codex o GPT-4 para generar código a partir de prompts.
+
+## Instalación
+
+```bash
+pip install -r requirements.txt
+```
+
+Crear un archivo `.env` con tu clave de OpenAI:
+
+```
+OPENAI_API_KEY=tu_clave
+```
+
+## Uso
+
+Iniciar la aplicación con:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Enviar un POST a `/generate` con un JSON que contenga el campo `prompt`.
+La respuesta incluirá el código generado y una explicación línea por línea.
+
+Ejemplo usando `curl`:
+
+```bash
+curl -X POST http://localhost:8000/generate \
+  -H "Content-Type: application/json" \
+  -d @test_prompt.json
+```
+
+## Interfaz web
+
+Con el backend en marcha puedes abrir `frontend/index.html` en tu navegador.
+Allí podrás introducir un prompt y ver el código generado junto con su explicación.

--- a/codex_quantum_tutor/app/main.py
+++ b/codex_quantum_tutor/app/main.py
@@ -1,0 +1,79 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+import openai
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+api_key = os.getenv("OPENAI_API_KEY")
+if not api_key:
+    raise RuntimeError("OPENAI_API_KEY not set")
+
+openai.api_key = api_key
+
+app = FastAPI(title="Codex Quantum Tutor")
+
+# Allow requests from any origin so the HTML file can be opened locally
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+class Prompt(BaseModel):
+    prompt: str
+
+@app.post("/generate")
+async def generate_code(data: Prompt):
+    try:
+        try:
+            chat_resp = openai.ChatCompletion.create(
+                model="gpt-4",
+                messages=[{"role": "user", "content": data.prompt}],
+                max_tokens=400,
+                temperature=0.3,
+            )
+            code_text = chat_resp.choices[0].message.content.strip()
+        except Exception:
+            resp = openai.Completion.create(
+                model="code-davinci-002",
+                prompt=data.prompt,
+                max_tokens=400,
+                temperature=0.3,
+            )
+            code_text = resp.choices[0].text.strip()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error generating code: {e}")
+
+    explanation_prompt = (
+        "Explica línea por línea el siguiente código en lenguaje natural, "
+        "como si enseñaras a un estudiante de computación cuántica:\n\n"
+        f"```python\n{code_text}\n```"
+    )
+
+    try:
+        try:
+            chat_resp = openai.ChatCompletion.create(
+                model="gpt-4",
+                messages=[{"role": "user", "content": explanation_prompt}],
+                max_tokens=400,
+                temperature=0.3,
+            )
+            explanation_text = chat_resp.choices[0].message.content.strip()
+        except Exception:
+            resp = openai.Completion.create(
+                model="code-davinci-002",
+                prompt=explanation_prompt,
+                max_tokens=400,
+                temperature=0.3,
+            )
+            explanation_text = resp.choices[0].text.strip()
+    except Exception as e:
+        raise HTTPException(
+            status_code=500, detail=f"Error generating explanation: {e}"
+        )
+
+    return {"code": code_text, "explanation": explanation_text}

--- a/codex_quantum_tutor/requirements.txt
+++ b/codex_quantum_tutor/requirements.txt
@@ -1,0 +1,4 @@
+openai
+fastapi
+uvicorn
+python-dotenv

--- a/codex_quantum_tutor/test_prompt.json
+++ b/codex_quantum_tutor/test_prompt.json
@@ -1,0 +1,3 @@
+{
+  "prompt": "Escribe un circuito en Qiskit que cree un estado de Bell y mide los qubits"
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Codex Quantum Tutor</title>
+    <style>
+        body { font-family: Arial, sans-serif; text-align: center; padding: 40px; }
+        textarea { width: 80%; height: 120px; }
+        pre { background: #f0f0f0; padding: 1em; text-align: left; white-space: pre-wrap; font-family: monospace; }
+        .section-title { font-weight: bold; margin-top: 1em; }
+        button { margin-top: 10px; }
+        #error { color: red; }
+    </style>
+</head>
+<body>
+    <h1>Codex Quantum Tutor</h1>
+    <textarea id="prompt" placeholder="Escribe tu prompt aquí..."></textarea><br>
+    <button id="generate">Generar código</button>
+    <div id="error"></div>
+    <div class="section-title" id="code-title" style="display:none;">Código generado</div>
+    <pre id="result"></pre>
+    <div class="section-title" id="explanation-title" style="display:none;">Explicación del código</div>
+    <pre id="explanation"></pre>
+
+    <script>
+    document.getElementById('generate').addEventListener('click', async () => {
+        const prompt = document.getElementById('prompt').value;
+        const resultEl = document.getElementById('result');
+        const explanationEl = document.getElementById('explanation');
+        const codeTitle = document.getElementById('code-title');
+        const explanationTitle = document.getElementById('explanation-title');
+        const errorEl = document.getElementById('error');
+        resultEl.textContent = '';
+        explanationEl.textContent = '';
+        codeTitle.style.display = 'none';
+        explanationTitle.style.display = 'none';
+        errorEl.textContent = '';
+        try {
+            const resp = await fetch('http://localhost:8000/generate', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ prompt })
+            });
+            if (!resp.ok) {
+                throw new Error('Error ' + resp.status);
+            }
+            const data = await resp.json();
+            resultEl.textContent = data.code;
+            explanationEl.textContent = data.explanation;
+            codeTitle.style.display = 'block';
+            explanationTitle.style.display = 'block';
+        } catch (err) {
+            errorEl.textContent = 'Ocurrió un error: ' + err.message;
+        }
+    });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extend README usage notes
- return line-by-line explanation from API
- show code and explanation on frontend

## Testing
- `python -m py_compile codex_quantum_tutor/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6848010e5a848326997a195d5369795f