### PR TITLE
Support knowledge level in /generate

### DIFF
--- a/codex_quantum_tutor/README.md
+++ b/codex_quantum_tutor/README.md
@@ -22,7 +22,8 @@ Iniciar la aplicación con:
 uvicorn app.main:app --reload
 ```
 
-Enviar un POST a `/generate` con un JSON que contenga el campo `prompt`.
+Enviar un POST a `/generate` con un JSON que contenga los campos `prompt` y
+`level`. El nivel puede ser `beginner`, `intermediate` o `advanced`.
 
 Ejemplo usando `curl`:
 
@@ -31,10 +32,7 @@ curl -X POST http://localhost:8000/generate \
   -H "Content-Type: application/json" \
   -d @test_prompt.json
 ```
- kczlam-codex/crear-proyecto-python-con-fastapi-y-codex
-
 ## Interfaz web
 
 Con el backend en marcha puedes abrir `frontend/index.html` en tu navegador.
 Allí podrás introducir un prompt y ver el código generado directamente.
-main

--- a/codex_quantum_tutor/app/main.py
+++ b/codex_quantum_tutor/app/main.py
@@ -1,9 +1,7 @@
 from fastapi import FastAPI, HTTPException
- kczlam-codex/crear-proyecto-python-con-fastapi-y-codex
 from fastapi.middleware.cors import CORSMiddleware
-
-main
 from pydantic import BaseModel
+from typing import Literal
 import openai
 from dotenv import load_dotenv
 import os
@@ -18,7 +16,6 @@ openai.api_key = api_key
 
 app = FastAPI(title="Codex Quantum Tutor")
 
- kczlam-codex/crear-proyecto-python-con-fastapi-y-codex
 # Allow requests from any origin so the HTML file can be opened locally
 app.add_middleware(
     CORSMiddleware,
@@ -27,18 +24,28 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
- main
+LEVEL_MSG = {
+    "beginner": "Responde con explicaciones sencillas y paso a paso.",
+    "intermediate": "Asume conocimientos básicos de computación cuántica.",
+    "advanced": "Utiliza terminología técnica y da detalles avanzados.",
+}
+
 class Prompt(BaseModel):
     prompt: str
+    level: Literal["beginner", "intermediate", "advanced"] = "beginner"
 
 @app.post("/generate")
 async def generate_code(data: Prompt):
     try:
+        instruction = LEVEL_MSG.get(data.level, "")
         # Try GPT-4 via chat completion
         try:
             chat_resp = openai.ChatCompletion.create(
                 model="gpt-4",
-                messages=[{"role": "user", "content": data.prompt}],
+                messages=[
+                    {"role": "system", "content": instruction},
+                    {"role": "user", "content": data.prompt},
+                ],
                 max_tokens=400,
                 temperature=0.3,
             )
@@ -46,7 +53,7 @@ async def generate_code(data: Prompt):
         except Exception:
             resp = openai.Completion.create(
                 model="code-davinci-002",
-                prompt=data.prompt,
+                prompt=f"{instruction}\n{data.prompt}",
                 max_tokens=400,
                 temperature=0.3,
             )

--- a/codex_quantum_tutor/test_prompt.json
+++ b/codex_quantum_tutor/test_prompt.json
@@ -1,3 +1,4 @@
 {
-  "prompt": "Escribe un circuito en Qiskit que cree un estado de Bell y mide los qubits"
+  "prompt": "Escribe un circuito en Qiskit que cree un estado de Bell y mide los qubits",
+  "level": "beginner"
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,6 +14,12 @@
 <body>
     <h1>Codex Quantum Tutor</h1>
     <textarea id="prompt" placeholder="Escribe tu prompt aquí..."></textarea><br>
+    <label for="level">Nivel:</label>
+    <select id="level">
+        <option value="beginner">Beginner</option>
+        <option value="intermediate">Intermediate</option>
+        <option value="advanced">Advanced</option>
+    </select>
     <button id="generate">Generar código</button>
     <div id="error"></div>
     <pre id="result"></pre>
@@ -21,6 +27,7 @@
     <script>
     document.getElementById('generate').addEventListener('click', async () => {
         const prompt = document.getElementById('prompt').value;
+        const level = document.getElementById('level').value;
         const resultEl = document.getElementById('result');
         const errorEl = document.getElementById('error');
         resultEl.textContent = '';
@@ -29,7 +36,7 @@
             const resp = await fetch('http://localhost:8000/generate', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ prompt })
+                body: JSON.stringify({ prompt, level })
             });
             if (!resp.ok) {
                 throw new Error('Error ' + resp.status);


### PR DESCRIPTION
## Summary
- clean up stray merge markers in `main.py` and rewrite file
- add `level` field so `/generate` tailors explanations for beginner, intermediate, or advanced users
- expose new `level` option in web frontend
- document new field and update example JSON

## Testing
- `python -m py_compile codex_quantum_tutor/app/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68484c507c108326a77d44637da60f10